### PR TITLE
matrix: add project homeserver

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -7,6 +7,7 @@ cfg = {
 
     ./hardware-configuration.nix
     ./website
+    ./matrix.nix
     base
     services
   ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -27,7 +27,7 @@ base = {
 
   system.stateVersion = "20.09";
 
-  nix-bitcoin.configVersion = "0.0.49";
+  nix-bitcoin.configVersion = "0.0.50";
 };
 
 services = {

--- a/krops/deploy.nix
+++ b/krops/deploy.nix
@@ -7,6 +7,8 @@ let
     website.file = {
       path = toString ../website;
     };
+    "matrix.nix".file = toString ../matrix.nix;
+    "mail.nix".file = toString ../mail.nix;
   };
 
   krops = (import <nix-bitcoin> {}).krops;

--- a/mail.nix
+++ b/mail.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+{
+  imports = [
+    (builtins.fetchTarball {
+      url = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/archive/5675b122a947b40e551438df6a623efad19fd2e7/nixos-mailserver-5675b122a947b40e551438df6a623efad19fd2e7.tar.gz";
+      sha256 = "1fwhb7a5v9c98nzhf3dyqf3a5ianqh7k50zizj8v5nmj3blxw4pi";
+    })
+  ];
+
+  mailserver = {
+    enable = true;
+    fqdn = "mail.nixbitcoin.org";
+    domains = [ "nixbitcoin.org" ];
+
+    localDnsResolver = false;
+
+    certificateScheme = 3;
+
+    virusScanning = false;
+  };
+
+  # Enable TLSv1, needed for matrix-synapse https://github.com/matrix-org/synapse/issues/6211
+  services.postfix.extraConfig = ''
+    smtpd_tls_protocols = TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, !SSLv2, !SSLv3
+    smtpd_tls_mandatory_protocols = TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, !SSLv2, !SSLv3
+  '';
+}

--- a/matrix.nix
+++ b/matrix.nix
@@ -1,0 +1,226 @@
+# This config enables
+# - Matrix Synapse homeserver available at synapse.nixbitcoin.org
+# - Matrix Element web client available at element.nixbitcoin.org
+#
+# Inspired by https://github.com/alarsyo/nixos-config/blob/main/services/matrix.nix
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  nbLib = config.nix-bitcoin.lib;
+  secretsDir = config.nix-bitcoin.secretsDir;
+  netns = config.nix-bitcoin.netns-isolation.netns;
+
+  inherit (config.services.matrix-synapse) dataDir;
+
+  synapseAddress = netns.matrix-synapse.address;
+  synapsePort = 8008;
+
+  requireSecrets = rec { wants = [ "nix-bitcoin-secrets.target" ]; after = wants; };
+in {
+  imports = [ ./mail.nix ];
+
+  # Limit systemd log retention for privacy reasons
+  services.journald.extraConfig = ''
+    MaxRetentionSec=24h
+    MaxFileSec=7day
+  '';
+
+  nix-bitcoin.netns-isolation.services = {
+    matrix-synapse = {
+      id = 28;
+      connections = [ "nginx" ];
+    };
+  };
+
+  services.tor.relay.onionServices.matrix-synapse = nbLib.mkOnionService {
+    port = 80;
+    target.addr = synapseAddress;
+    target.port = synapsePort;
+  };
+
+  services.postgresql = {
+    enable = true;
+    initialScript = builtins.toFile "synapse-init.sql" ''
+      CREATE ROLE "matrix-synapse" WITH LOGIN PASSWORD 'synapse';
+      CREATE DATABASE "matrix-synapse" WITH OWNER "matrix-synapse"
+        TEMPLATE template0
+        LC_COLLATE = "C"
+        LC_CTYPE = "C";
+    '';
+  };
+
+  mailserver.loginAccounts = {
+    "synapse@nixbitcoin.org" = {
+      hashedPasswordFile = "${secretsDir}/matrix-smtp-password-hashed";
+      sendOnly = true;
+    };
+  };
+  # hashedPasswordFile is used by dovecot2
+  systemd.services.dovecot2 = requireSecrets;
+
+  services.matrix-synapse = {
+    enable = true;
+    enable_registration = true;
+    extraConfigFiles =  [ "${dataDir}/secret-email-config" ];
+    database_args = {
+      database = "matrix-synapse";
+      user = "matrix-synapse";
+      host = "/run/postgresql";
+    };
+    server_name = "nixbitcoin.org";
+    public_baseurl = "https://synapse.nixbitcoin.org";
+    listeners = [
+      {
+        bind_address = synapseAddress;
+        port = synapsePort;
+        type = "http";
+        tls = false;
+        x_forwarded = true;
+        resources = [
+          {
+            names = [ "client" "federation" ];
+            compress = false;
+          }
+        ];
+      }
+    ];
+    extraConfig = ''
+      push:
+        include_content: false
+
+      registrations_require_3pid:
+        - email
+
+      enable_metrics: false
+      report_stats: false
+
+      auto_join_rooms:
+        - "#general:nixbitcoin.org"
+
+      retention:
+        enabled: true
+        purge_jobs:
+        - longest_max_lifetime: 1w
+          interval: 12h
+
+      allow_profile_lookup_over_federation: false
+      allow_device_name_lookup_over_federation: false
+      include_profile_data_on_invite: false
+      limit_profile_requests_to_users_who_share_rooms: true
+      require_auth_for_profile_requests: true
+    '';
+  };
+
+  systemd.services.matrix-synapse = let
+    emailConfig = builtins.toFile "email-config" ''
+      email:
+        smtp_host: mail.nixbitcoin.org
+        smtp_port: 587
+        smtp_user: "synapse@nixbitcoin.org"
+        notif_from: "Your Friendly %(app)s homeserver <synapse@nixbitcoin.org>"
+    '';
+  in {
+    preStart = ''
+      {
+        cat ${emailConfig}
+        echo -n '  smtp_pass: "'
+        tr -d '\n' <${secretsDir}/matrix-smtp-password
+        echo '"'
+      } > "${dataDir}/secret-email-config"
+    '';
+    serviceConfig =
+      nbLib.defaultHardening //
+      nbLib.allowAllIPAddresses // {
+        ReadWritePaths = dataDir;
+        MemoryDenyWriteExecute = false;
+      };
+  } // requireSecrets;
+
+  services.nginx = {
+    enable = true;
+    # Only recommendedProxySettings and recommendedGzipSettings are strictly required,
+    # but the rest make sense as well
+    recommendedTlsSettings = true;
+    recommendedOptimisation = true;
+    recommendedGzipSettings = true;
+    recommendedProxySettings = true;
+
+    virtualHosts = {
+      # .well-known locations for matrix
+      "nixbitcoin.org" = {
+        enableACME = true;
+        forceSSL = true;
+
+        locations."= /.well-known/matrix/server".extraConfig = ''
+            add_header Content-Type application/json;
+            return 200 '${builtins.toJSON {
+              # use 443 instead of the default 8448 port to unite
+              # the client-server and server-server port for simplicity
+              "m.server" = "synapse.nixbitcoin.org:443";
+            }}';
+          '';
+        locations."= /.well-known/matrix/client".extraConfig =
+          # ACAO required to allow element-web on any URL to request this json file
+          ''
+            add_header Content-Type application/json;
+            add_header Access-Control-Allow-Origin *;
+            return 200 '${builtins.toJSON {
+              "m.homeserver" =  { "base_url" = "https://synapse.nixbitcoin.org"; };
+              "m.identity_server" =  { "base_url" = "https://vector.im"; };
+            }}';
+          '';
+      };
+
+      # Reverse proxy for Matrix client-server and server-server communication
+      "synapse.nixbitcoin.org" = {
+        enableACME = true;
+        forceSSL = true;
+
+        # Don't show nginx welcome page
+        locations."/".extraConfig = ''
+          return 404;
+        '';
+
+        # forward all Matrix API calls to the synapse Matrix homeserver
+        locations."/_matrix" = {
+          proxyPass = "http://${synapseAddress}:${toString synapsePort}";
+        };
+      };
+
+      "element.nixbitcoin.org" = {
+        enableACME = true;
+        forceSSL = true;
+
+	      root = pkgs.element-web.override {
+	        conf = {
+	          default_server_config."m.homeserver" = {
+	            "base_url" = "https://synapse.nixbitcoin.org";
+	            "server_name" = "nixbitcoin.org";
+	          };
+	        };
+	      };
+      };
+    };
+  };
+
+  # Backups
+  services.postgresqlBackup = {
+    enable = true;
+    databases = [ "matrix-synapse" ];
+  };
+  systemd.services.duplicity = rec {
+    wants = [ "postgresqlBackup-matrix-synapse.service" ];
+    after = wants;
+  };
+  services.backups.extraFiles = [
+    dataDir
+    "${config.services.postgresqlBackup.location}/matrix-synapse.sql.gz"
+  ];
+
+  nix-bitcoin.secrets.matrix-smtp-password.user = "matrix-synapse";
+  # Used by dovecot2 (via the mailserver module)
+  nix-bitcoin.secrets.matrix-smtp-password-hashed.user = "root";
+}

--- a/nix-bitcoin-release.nix
+++ b/nix-bitcoin-release.nix
@@ -1,4 +1,4 @@
 {
-  url = "https://github.com/fort-nix/nix-bitcoin/releases/download/v0.0.49/nix-bitcoin-0.0.49.tar.gz";
-  sha256 = "8142d13dc644929091a18a35e989fd1d2ac5dd74c0544c443199798ff2147a48";
+  url = "https://github.com/fort-nix/nix-bitcoin/releases/download/v0.0.50/nix-bitcoin-0.0.50.tar.gz";
+  sha256 = "0qv2jfz4civqd20wrbsjb7qg81icsk5rwggqh95pszvnz4fzxdz4";
 }

--- a/website/default.nix
+++ b/website/default.nix
@@ -76,11 +76,10 @@ in {
     services.btcpayserver.rootpath = "btcpayserver";
 
     services.tor.relay.onionServices.nginx = {
-      map = [{
-        port = 80; target.addr = nginxAddress; target.port = 80;
-      } {
-        port = 443; target.addr = nginxAddress; target.port = 443;
-      }];
+      map = [
+        rec { port = 80;  target = { addr = nginxAddress; inherit port; }; }
+        rec { port = 443; target = { addr = nginxAddress; inherit port; }; }
+      ];
       version = 3;
     };
   }

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -145,6 +145,9 @@
         s3cqv57f3vvyrgwm7v3avkvkft5xesy27goaexkql6a55yevyi5bc3qd.onion:50001:t
       </code>
     </ul>
+    <h4>Matrix Homeserver</h4>
+
+    <a href="https://element.nixbitcoin.org">@nixbitcoin.org homeserver</a> - matrix-synapse homeserver with open registration (email required).
 
     <h4>JoinMarket Orderbook</h4>
 


### PR DESCRIPTION
We should be self-reliant for our communication infrastructure. This matrix homeserver configuration is running live on [synapse.nixbitcoin.org](https://synapse.nixbitcoin.org) and reachable on [Tor](http://outwtosg7hmgmeivjwbhxryp7vjwzxu3ebg24myaaupluwioxeqchmqd.onion). Please review. Message me if you want an account.