### PR TITLE
bitcoind: whitelist nbxplorer IP

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -34,6 +34,10 @@ base = {
 services = {
   nix-bitcoin.onionServices.bitcoind.public = true;
 
+  services.bitcoind.extraConfig = ''
+    whitelist=169.254.1.23
+  '';
+
   services.clightning = {
     enable = true;
     plugins.clboss.enable = true;


### PR DESCRIPTION
I assume this is something we have to patch in nix-bitcoin.

Was getting

```
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: TCP Connection succeed, handshaking...
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: Handshaked
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Loading chain from node
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: Loading chain...
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: Chain loaded
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: warn: Explorer:       BTC: Your NBXplorer server is not whitelisted by your node, you should add "whitelist=169.254.1.23" to the configuration file of your node. (Or use whitebind)
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Height: 700643
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: Handshaked node
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Explorer:       BTC: Starting scan at block 700640
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Events:         BTC: Node state changed: NotStarted => NBXplorerSynching
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: info: Events:         BTC: Node state changed: NBXplorerSynching => Ready
Sep 15 11:10:52 nixbitcoin-org nbxplorer[2294]: fail: Explorer:       BTC: Connection unexpectedly failed: Unexpected exception while connecting to socket
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Events:         BTC: Node state changed: Ready => NotStarted
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Testing RPC connection to http://169.254.1.12:8332/
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: RPC connection successful
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Full node version detected: 210100
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Loading chain from cache...
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Height: 700643
Sep 15 11:10:53 nixbitcoin-org nbxplorer[2294]: info: Configuration:  BTC: Trying to connect via the P2P protocol to trusted node (169.254.1.12:8333)...
```