### PR TITLE
Prepare nixbitcoin.org for use as nix-bitcoin addnode

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -33,6 +33,7 @@ base = {
 
 services = {
   nix-bitcoin.onionServices.bitcoind.public = true;
+  services.bitcoind.enforceTor = lib.mkForce false;
 
   services.clightning = {
     enable = true;

--- a/configuration.nix
+++ b/configuration.nix
@@ -63,6 +63,8 @@ services = {
   services.joinmarket-ob-watcher.enable = true;
 
   nix-bitcoin-org.website.enable = true;
+
+  services.backups.enable = true;
 };
 in
   cfg

--- a/configuration.nix
+++ b/configuration.nix
@@ -43,6 +43,7 @@ services = {
     '';
   };
   nix-bitcoin.onionServices.clightning.public = true;
+  systemd.services.clightning.serviceConfig.TimeoutStartSec = "5m";
 
   services.electrs.enable = true;
 


### PR DESCRIPTION
`bitcoind` onion address is `7pyrpvqdhmayxggpcyqn5l3m5vqkw3qubnmgwlpya2mdo6x7pih7r7id.onion`

See https://github.com/fort-nix/nix-bitcoin/commit/0c31130ac8bf96372595912b3b932413561245b1