### PR TITLE
Support LNURL for donations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ for [nixbitcoin.org](https://nixbitcoin.org)
 
 Run `nix-shell` to enter a dev shell ([`shell.nix`](./shell.nix)) which provides
 commands for running the node in a container or VM.
+
+### Highlights:
+- A proof of concept [donation page](https://nixbitcoin.org/donate) ([src](./website/donate/default.nix)) with payment methods:
+  - LNURL ([LUD-06](https://github.com/fiatjaf/lnurl-rfc/blob/luds/06.md)
+    and [LUD-16](https://github.com/fiatjaf/lnurl-rfc/blob/luds/16.md)/[Lightning Address](https://lightningaddress.com/)),
+  - bolt11
+  - Bitcoin on-chain
+  - Liquid on-chain
+- A Matrix synapse homeserver ([src](./matrix.nix)) with email registrations via a self-hosted [mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver).

--- a/configuration.nix
+++ b/configuration.nix
@@ -66,7 +66,11 @@ services = {
   };
   services.joinmarket-ob-watcher.enable = true;
 
-  nix-bitcoin-org.website.enable = true;
+  nix-bitcoin-org.website = {
+    enable = true;
+    donate.btcpayserverAppId = "4D1Dxb5cGnXHRgNRBpoaraZKTX3i";
+    donate.btcpayserverAppIdLnurl = "TODO";
+  };
 
   services.backups.enable = true;
 };

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,10 @@ let
 
     Commands for nixbitcoin.org
     ===========================
+    run-test
+      Run the test for this repo.
+      (Starts a container, so root privileges are required.)
+
     container, co
       Run node in a container and start a shell for interacting with the container.
       (Requires root privileges.)
@@ -79,7 +83,9 @@ let
               exec ${nix-bitcoin}/test/run-tests.sh "$@"
           '')
           extra-container.pkg
-          # Used by test/cmds/website
+          # Used by test/
+          curl
+          jq
           lynx
         ];
       };

--- a/shell.nix
+++ b/shell.nix
@@ -53,6 +53,8 @@ let
       Print all nginx configuration files of the `website` scenario
 
 
+    => Also see ./test/dev.sh which includes snippets for developing and adhoc testing.
+
     => This shell environment can be captured with direnv/lorri
   '';
 

--- a/shell.nix
+++ b/shell.nix
@@ -45,6 +45,9 @@ let
       Launch the node in a container, render the website as text, shutdown node.
       (Requires root privileges.)
 
+    nginx-conf
+      Print all nginx configuration files of the `website` scenario
+
 
     => This shell environment can be captured with direnv/lorri
   '';

--- a/test/btcpayserver-config/default.nix
+++ b/test/btcpayserver-config/default.nix
@@ -10,6 +10,11 @@ let
   psql = "${config.services.postgresql.package}/bin/psql";
 in
 {
+  nix-bitcoin-org.website.donate = {
+    btcpayserverAppId = lib.mkForce "qJ1NExmDYQLr6MoyZFypeeFgLNj";
+    btcpayserverAppIdLnurl = lib.mkForce "3UPqaCWn98kHQkt8jmqW2wbfVM3H";
+  };
+
   systemd.services.importBtcpayserverConfig = rec {
     requires = [ "postgresql.service" ];
     after = requires;

--- a/test/cmds/nginx-conf
+++ b/test/cmds/nginx-conf
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "${BASH_SOURCE[0]%/*}"
+
+# Show the all nginx configuration files of the website config
+
+expr='((import ../eval-config.nix).config "website").environment.etc."nginx/nginx.conf".source'
+config=$(nix build --impure --no-link --json --expr "$expr" | jq -r '.[].outputs | .[]')
+commonConfig=$(cat "$config" | grep -ohP '(?<=include )/nix/store.*common.conf' | head -1)
+cat "$config"
+echo
+echo "Common config"
+cat "$commonConfig"

--- a/test/cmds/run-test
+++ b/test/cmds/run-test
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Name `test` is reserved by POSIX, use `run-test` instead.
+# With option `--debug`, start a debug shell on test failure.
+
+set -euo pipefail
+
+scenario=nixbitcoinorg-container
+case ${1-} in
+  --website|-w)
+    # The minimum required scenario for ../test.sh
+    scenario=website
+    ;;
+esac
+
+exec container $scenario --run "${BASH_SOURCE[0]%/*}"/../test.sh "$@"

--- a/test/cmds/test
+++ b/test/cmds/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec run-test "$@"

--- a/test/dev.sh
+++ b/test/dev.sh
@@ -1,0 +1,44 @@
+### Commands and snippets for testing and exploring the node config
+# Run these from within the nix-shell (nix-shell ../shell.nix)
+
+# The main test suite. Runs offline.
+# Starts a fully-featured node, checks that all
+# systemd units succeed at startup and runs ./test.sh
+run-test
+
+# Runs ./test.sh in fast node config that only includes the website.
+# Also includes online tests.
+run-test --website
+
+
+### Website
+## Run the following commands in a container shell:
+co website
+
+curl $ip
+lynx -dump $ip
+lynx -dump $ip/donate
+lynx -dump $ip/donate/other
+
+# Create invoice via LNURL
+curl -sS $ip/donate/lightning | jq
+
+# Create invoice via catch-all Lightning Address *@nixbitcoin.org
+curl -sS $ip/.well-known/lnurlp/donate | jq
+curl -sS $ip/.well-known/lnurlp/foo | jq
+
+# Create Lightning invoice via LNURL. (Not functional in regtest.)
+curl -sS $(curl -sS $ip/donate/lightning | jq -r .callback)?amount=1000 | jq
+
+# Create invoice via other methods
+curl -v -L -X POST -d '' $ip/donate/other
+
+source ./test-lib.sh
+# Show invoices
+btcpAPI get stores/$(btcpAPI get stores | jq -r '.[].id')/invoices
+
+# Open donation page in browser
+runuser -u $(logname) -- xdg-open http://$ip/donate
+
+# Open btcpayserver admin interface. Mail: a@a Password: aaaaaaa
+runuser -u $(logname) -- xdg-open http://$ip:23000/btcpayserver

--- a/test/eval-config.nix
+++ b/test/eval-config.nix
@@ -1,0 +1,6 @@
+rec {
+  tests = import <nix-bitcoin/test/tests.nix> {
+    extraScenarios = import ./scenarios.nix;
+  };
+  config = test: tests.${test}.vm.nodes.machine.config;
+}

--- a/test/scenarios.nix
+++ b/test/scenarios.nix
@@ -115,6 +115,7 @@ rec {
     services.btcpayserver.enable = mkForce true;
     # Required for btcpayserver currency rate fetching
     test.container.enableWAN = true;
+    environment.variables.WANEnabled = "1";
   };
 
   # To demonstrate failures in the test runner

--- a/test/scenarios.nix
+++ b/test/scenarios.nix
@@ -11,6 +11,7 @@ rec {
       ../configuration.nix
       scenarios.regtestBase
       disableFeatures
+      ./btcpayserver-config
     ];
 
     # Improve eval performance by reusing pkgs
@@ -112,6 +113,8 @@ rec {
     nix-bitcoin-org.website.enable = mkForce true;
     services.clightning.enable = mkForce true;
     services.btcpayserver.enable = mkForce true;
+    # Required for btcpayserver currency rate fetching
+    test.container.enableWAN = true;
   };
 
   # To demonstrate failures in the test runner

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -94,3 +94,24 @@ isWANenabled() {
   fi
   [[ $WANStatus == 1 ]]
 }
+
+btcpCurl() {
+  method=$1
+  shift
+  curl -sS -H "Content-Type: application/json" --user "a@a.a:aaaaaa" \
+       "$@" "$ip:23000/btcpayserver/api/v1/$method" | jq
+}
+
+btcpAPI() {
+  type=$1
+  method=$2
+  shift
+  shift
+  if [[ $type == get ]]; then
+    btcpCurl $method -X get "$@"
+  else
+    body=$3
+    shift
+    btcpCurl $method -X post -d "$body"
+  fi
+}

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -1,0 +1,96 @@
+burstLimitIgnoreInternalResponse=
+
+getBurstLimit() {
+  type=$1
+  url=$2
+  max=100
+
+  if [[ $type == GET ]]; then
+    okStatus=200
+    curlArgs=()
+  else
+    # POST
+    okStatus=302
+    curlArgs=(-X POST -d '')
+  fi
+
+  for ((i=0; i<$max; i++)); do
+    status=$(getStatusCode "${curlArgs[@]}" "$url")
+    if [[ $status != $okStatus ]]; then
+      if [[ $status == 429 ]]; then
+        echo $i
+        return
+      elif [[ ! $burstLimitIgnoreInternalResponse ]]; then
+        >&2 echo "Unexpected status code ($status) for $url"
+        return 1
+      fi
+    fi
+  done
+  >&2 echo "Max burst limit ($max) exceeded for $url"
+  return 1
+}
+
+getStatusCode() {
+  maxTime=
+  if [[ $burstLimitIgnoreInternalResponse ]]; then
+    maxTime="--max-time 0.02"
+  fi
+  curl -s $maxTime -o /dev/null -w "%{http_code}" "$@"
+}
+
+assertBurstLimit() {
+  expected=$1
+  type=$2
+  url=$3
+  actual=$(getBurstLimit "$type" "$url")
+  tolerance=5
+  if ((actual < expected || actual - expected > tolerance)); then
+    >&2 echo "Unexpected burst limit: $actual. Expected: $expected ($type $url)"
+    return 1
+  fi
+}
+
+assertMatches() {
+  expected="$1"
+  actual="$2"
+  if [[ $actual != $expected ]]; then
+    echo
+    echo 'Pattern does not match'
+    echo 'Expected:'
+    echo "$expected"
+    echo
+    echo 'Actual:'
+    echo "$actual"
+    echo
+    return 1
+  fi
+}
+
+waitForPort() {
+  address=$1
+  port=$2
+  attempts=200
+  while ! { exec 3>/dev/tcp/$address/$port && exec 3>&-; } &>/dev/null; do
+    ((attempts-- == 0)) && { echo "Error: $address:$port is unreachable"; exit 1; }
+    sleep 0.01
+  done
+}
+
+restartNginx() {
+  # Run `reset-failed` to reset service restart counters.
+  # This avoids error `start-limit-hit` after many restarts
+  c bash -c 'systemctl restart nginx && systemctl reset-failed nginx'
+  waitForPort $ip 80
+}
+
+WANStatus=
+isWANenabled() {
+  if [[ ! $WANStatus ]]; then
+    if c bash -c '[[ $WANEnabled ]]'; then
+      WANStatus=1
+    else
+      WANStatus=0
+    fi
+  fi
+  [[ $WANStatus == 1 ]]
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is run in a container shell by
+# ./cmds/run-test
+
+# To manually run (parts of) the test, start the nix shell of this project, run
+# `container website` or `co website` and execute test commands in the container shell.
+
+cd "${BASH_SOURCE[0]%/*}"
+source ./test-lib.sh
+
+trap 'echo Error at line $LINENO' ERR
+
+echo "Test main donation page"
+assertMatches "*donate@nixbitcoin.org*" "$(curl -sS http://$ip/donate)"
+
+echo -n "Wait until btcpayserver serves content..."
+while [[ $(getStatusCode http://$ip/donate/other) != 200 ]]; do
+  sleep 0.1
+done
+echo "Done"
+
+echo "Test rate limits"
+assertBurstLimit 20 GET http://$ip
+restartNginx # Reset rate limit counters
+assertBurstLimit 20 GET http://$ip/donate
+restartNginx
+assertBurstLimit 20 GET http://$ip/donate/other
+restartNginx
+
+if isWANenabled; then
+  echo "Running tests in online mode"
+else
+  # For the following invoice-generating requests, btcpayserver
+  # requires an internet connection for rate-fetching (even for the
+  # Bitcoin-only LNURL invoice).
+  # Set this variable to ignore the btcpayserver failure and just check for the
+  # nginx-generated status code (429) that indicates active rate limiting.
+  burstLimitIgnoreInternalResponse=1
+fi
+
+# Test stricter rate limits for invoice generation
+assertBurstLimit 10 GET http://$ip/donate/lightning
+restartNginx
+assertBurstLimit 10 POST http://$ip/donate/other
+restartNginx
+
+if isWANenabled; then
+  echo "Test lnurl invoice"
+  curl -sS http://$ip/donate/lightning | jq -e 'has("callback")' >/dev/null
+fi
+
+echo "Success"

--- a/website/default.nix
+++ b/website/default.nix
@@ -68,6 +68,18 @@ in {
       recommendedOptimisation = true;
       recommendedTlsSettings = true;
       commonHttpConfig = ''
+        # Add rate limiting:
+        # At any given time, the number of total requests per IP is limited to
+        # (rate * time_elapsed + burst) = (10 * seconds_elapsed + 20)
+        # Additional requests are rejected with error 429.
+        #
+        limit_req_zone $binary_remote_addr zone=global:10m rate=10r/s;
+        limit_req zone=global burst=20 nodelay;
+
+        # 429: "Too Many Requests"
+        limit_conn_status 429;
+        limit_req_status 429;
+
         # Disable the access log for user privacy
         access_log off;
       '';

--- a/website/default.nix
+++ b/website/default.nix
@@ -50,9 +50,14 @@ in {
 
       add_header Onion-Location http://qvzlxbjvyrhvsuyzz5t63xx7x336dowdvt7wfj53sisuun4i4rdtbzid.onion$request_uri;
 
-      location /obwatcher/ {
+      location /orderbook/ {
         proxy_pass http://${serviceAddress "joinmarket-ob-watcher"};
-        rewrite /obwatcher/(.*) /$1 break;
+        rewrite /orderbook/(.*) /$1 break;
+      }
+
+      # Redirect old obwatcher path
+      location /obwatcher {
+        rewrite /obwatcher(.*) /orderbook$1 permanent;
       }
     '';
 

--- a/website/donate/debug.sh
+++ b/website/donate/debug.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Call make-donation-page.py, print and save its output.
+# Cache python environment for fast testing cycles.
+
+cd "${BASH_SOURCE[0]%/*}"
+
+# Hash of build dependencies
+hash=$(
+  {
+    echo "$NIX_PATH"
+    cat make-donation-page.nix python-packages.nix
+  } | sha1sum | cut -f1 -d' '
+)
+
+cachePrefix=/tmp/nixbitcoinorg-donate
+cachedEnv=$cachePrefix-$hash
+if [[ ! -e $cachedEnv ]]; then
+  rm -f $cachePrefix-*
+  nix-build --out-link $cachedEnv make-donation-page.nix -A python >/dev/null
+fi
+
+args='{
+  "donate_other_methods_url": "http://10.225.255.2/btcpayserver/apps/2TgtfG5UAW8BhEyrQy9rzyeSNDZp/pos",
+  "title": "Donate - nix-bitcoin",
+  "lnurl_plaintext": "https://nixbitcoin.org/donate/lightning",
+  "lightning_address": "test@nixbitcoin.org",
+  "url_prefix": "http://10.225.255.2"
+}'
+$cachedEnv/bin/python make-donation-page.py "$args" > donate.html
+cat donate.html
+echo "Wrote donate.html"

--- a/website/donate/default.nix
+++ b/website/donate/default.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  options = {
+    nix-bitcoin-org.website.donate = {
+      btcpayserverAppId = mkOption {
+        type = types.str;
+      };
+      btcpayserverAppIdLnurl = mkOption {
+        type = types.str;
+      };
+    };
+  };
+
+  cfg = config.nix-bitcoin-org.website.donate;
+
+  donate = import ./make-donation-page.nix { pkgs = config.nix-bitcoin.pkgs.pinned.pkgsUnstable; };
+
+  webpage = donate.mkPage {
+    title = "Donate - nix-bitcoin";
+    lnurl_plaintext = "https://nixbitcoin.org/donate/lightning";
+    donate_other_methods_url = "/donate/other";
+    lightning_address = "donate@nixbitcoin.org";
+  };
+
+  btcpayserverPayRequest = "/btcpayserver/BTC/LNURL/pay/app/${cfg.btcpayserverAppIdLnurl}/donate";
+
+  btcpayserverAddress = with config.services.btcpayserver; "${address}:${toString port}";
+in {
+  inherit options;
+
+  config = {
+    nix-bitcoin-org.website.nginxHostConfig =''
+      location /btcpayserver/ {
+        proxy_pass http://${btcpayserverAddress};
+
+        # Disallow access to the btcpayserver admin interface and the API
+        location ~* ^/btcpayserver/(login|register|account|api|)(?:$|/) {
+          return 404;
+        }
+      }
+
+      location = /donate {
+        default_type "text/html";
+        alias ${webpage};
+      }
+
+      location = /donate/other {
+        rewrite ^ /btcpayserver/apps/${cfg.btcpayserverAppId}/pos;
+      }
+
+      # Forward the fixed location lnurl to btcpayserver (lnurl LUD-06)
+      location = /donate/lightning {
+        rewrite ^ ${btcpayserverPayRequest};
+      }
+
+      # Forward all lightning addresses (*@nixbitcoin.org) to btcpayserver (lnurl LUD-16)
+      location /.well-known/lnurlp/ {
+        rewrite ^ ${btcpayserverPayRequest};
+      }
+    '';
+  };
+}

--- a/website/donate/default.nix
+++ b/website/donate/default.nix
@@ -31,6 +31,12 @@ in {
   inherit options;
 
   config = {
+    # Allow 2 invoices per minute and IP, with a burst limit of 10.
+    # See the `rate limiting` comment in ../default.nix for details.
+    services.nginx.commonHttpConfig = ''
+      limit_req_zone $binary_remote_addr zone=btcp_invoice:10m rate=2r/m;
+    '';
+
     nix-bitcoin-org.website.nginxHostConfig =''
       location /btcpayserver/ {
         proxy_pass http://${btcpayserverAddress};
@@ -39,6 +45,35 @@ in {
         location ~* ^/btcpayserver/(login|register|account|api|)(?:$|/) {
           return 404;
         }
+
+        ## Add extra rate limits for invoice generation
+
+        # 1. Rate-limit the lnurl app
+        location /btcpayserver/BTC/LNURL/pay/app/${cfg.btcpayserverAppIdLnurl} {
+          proxy_pass http://${btcpayserverAddress};
+          limit_req zone=btcp_invoice burst=10 nodelay;
+        }
+
+        # 2. Rate-limit the regular app (/donate/other)
+        # GET requests to this location only return the donation interface.
+        # Add extra rate limiting only for POST requests where invoice generation happens.
+        #
+        location /btcpayserver/apps/${cfg.btcpayserverAppId} {
+          if ($request_method = POST) {
+            # Return to a named location (@btcp) because `if` statements
+            # inside location blocks may only return or rewrite.
+            return 590;
+          }
+          proxy_pass http://${btcpayserverAddress};
+        }
+      }
+
+      # Required for jumping to named location @btcp_limit_post
+      error_page 590 = @btcp_limit_post;
+
+      location @btcp_limit_post {
+        limit_req zone=btcp_invoice burst=10 nodelay;
+        proxy_pass http://${btcpayserverAddress};
       }
 
       location = /donate {

--- a/website/donate/donate-template.html
+++ b/website/donate/donate-template.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html class="h-100"><head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>${title}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="${url_prefix}/btcpayserver/img/icons/icon-512x512.png">
+    <link rel="apple-touch-startup-image" href="${url_prefix}/btcpayserver/img/splash.png">
+    <link rel="manifest" href="${url_prefix}/btcpayserver/manifest.json">
+    <link href="${url_prefix}/btcpayserver/bundles/main-bundle.min.css" rel="stylesheet" />
+    <link href="${url_prefix}/btcpayserver/main/themes/default.css" rel="stylesheet" />
+    <style>
+      .card-deck {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          grid-gap: 1.5rem;
+      }
+      .card:only-of-type {
+          max-width: 320px;
+          margin: auto !important;
+      }
+      body {
+          margin: 0;
+      }
+      #donate-other {
+          display: block; height: 60vh; width: 100vw; border: 0; padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <div class="container d-flex h-100">
+        <div class="justify-content-center align-self-center text-center mx-auto px-2 py-3 w-100 m-auto">
+          <div class="card-deck my-3 mx-auto">
+            <div class="card px-0" data-id="0">
+              <div class="card-body my-auto pb-0">
+                <h5 class="card-title">Donate via lnurl</h5>
+              </div>
+              <div class="card-footer bg-transparent border-0 pb-3">
+                <div class="w-100 text-center text-muted">
+                  <span>Any amount</span>
+                </div>
+                ${lnurl_qrcode}
+                <a href="${lnurl}" class="btn btn-secondary d-print-none w-100 mt-2 lnurl" data-choice="donate" rel="noreferrer noopener">
+                  Open in wallet
+                </a>
+                <div class="w-100 pt-3 text-center">
+                  <span>Lightning Address<br /><strong>${lightning_address}</strong></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <iframe id="donate-other" src='${donate_other_methods_url}' />
+  </body>
+</html>

--- a/website/donate/make-donation-page.nix
+++ b/website/donate/make-donation-page.nix
@@ -1,0 +1,30 @@
+let
+  nix-bitcoin = toString (import ../../nix-bitcoin-release.nix);
+  pinned = import "${nix-bitcoin}/pkgs/nixpkgs-pinned.nix";
+  nixpkgsUnstable = pinned.nixpkgs-unstable;
+in
+{ pkgs ? import nixpkgsUnstable { config = {}; overlays = []; } }:
+let
+  py = pkgs.python3;
+  pyPkgs = import ./python-packages.nix;
+
+  mkPkg = py.pkgs.callPackage;
+  bech32 = mkPkg pyPkgs.bech32 {};
+  lnurl = mkPkg pyPkgs.lnurl { inherit bech32; };
+
+  python = py.withPackages (ps: with ps; [
+    lnurl
+    qrcode
+  ]);
+in {
+  inherit python;
+
+  mkPage = args:
+    pkgs.runCommand "donate.html" {
+      donate_args = builtins.toJSON (args // {
+        html_template = ./donate-template.html;
+      });
+    } ''
+      ${python}/bin/python ${./make-donation-page.py} "$donate_args" > $out
+    '';
+}

--- a/website/donate/make-donation-page.py
+++ b/website/donate/make-donation-page.py
@@ -1,0 +1,41 @@
+import json
+import lnurl as Lnurl
+import os
+import qrcode
+import qrcode.image.svg
+import sys
+import re
+from pathlib import Path
+from string import Template
+
+def create_donation_page(donate_other_methods_url,
+                         title,
+                         lnurl_plaintext,
+                         lightning_address,
+                         bg_color='#f5f5f7',
+                         html_template=os.path.join(os.path.dirname(__file__), 'donate-template.html'),
+                         # for debugging
+                         url_prefix=''):
+    lnurl = f"lightning:{Lnurl.encode(lnurl_plaintext).lower()}"
+    lnurl_qrcode = make_qrcode(lnurl, bg_color)
+    template = Template(Path(html_template).read_text())
+    html = template.substitute(title=title,
+                               lnurl_qrcode=lnurl_qrcode,
+                               lnurl=lnurl,
+                               lightning_address=lightning_address,
+                               donate_other_methods_url=donate_other_methods_url,
+                               url_prefix=url_prefix)
+    return html
+
+
+def make_qrcode(lnurl_encoded, bg_color):
+    img = qrcode.make(lnurl_encoded, image_factory=qrcode.image.svg.SvgPathImage)
+    svg = img.to_string().decode('utf-8')
+    svg = re.sub(r'width=".*?" height=".*?"', 'shape-rendering="crispEdges"', svg, count=1)
+    # Add background rect before first <path> element
+    svg = re.sub(r'<path', f'<rect x="0" y="0" width="256" height="256" fill="{bg_color}"></rect><path', svg, count=1)
+    return svg
+
+args = json.loads(sys.argv[1])
+html = create_donation_page(**args)
+print(html)

--- a/website/donate/python-packages.nix
+++ b/website/donate/python-packages.nix
@@ -1,0 +1,27 @@
+{
+  bech32 = { buildPythonPackage, fetchurl }: buildPythonPackage rec {
+    pname = "bech32";
+    version = "1.2.0";
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/b6/41/7022a226e5a6ac7091a95ba36bad057012ab7330b9894ad4e14e31d0b858/bech32-1.2.0-py3-none-any.whl";
+      sha256 = "10frg6gdwb3mnccllady83dp76yxbwqva1sjynyspzp4lpjwh3cr";
+    };
+    format = "wheel";
+    doCheck = false;
+  };
+  lnurl = { buildPythonPackage, fetchurl, bech32, pydantic, typing-extensions }: buildPythonPackage rec {
+    pname = "lnurl";
+    version = "0.3.6";
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/a6/cf/ca4e80e16bc3aae5d84dbc28554ef5b26b0d7460775090ff3579ca185b6f/lnurl-0.3.6-py3-none-any.whl";
+      sha256 = "14lw7crvlq01xdd5svs2l8gzm6brrd2yqx0wqs2bq9adikyq56ap";
+    };
+    format = "wheel";
+    doCheck = false;
+    propagatedBuildInputs = [
+      bech32
+      pydantic
+      typing-extensions
+    ];
+  };
+}


### PR DESCRIPTION
[Here's the diff](https://github.com/erikarvstedt/extra-container/compare/master..374bd0c2ae55db1bf7ae940e16cfdf01ee204cfd) for the extra-container update.

To check out the donations page, run
```
container website --run bash -c 'runuser -u $(logname) -- xdg-open http://$ip/donate && sleep infinity'
# Now refresh the browser until btcpayserver serves the lower half of the donation page.
```